### PR TITLE
Enhance sitemap functionality with URL validation

### DIFF
--- a/demo/mule-webcrawler-connector-operations-demo/pom.xml
+++ b/demo/mule-webcrawler-connector-operations-demo/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>com.mulesoft.connectors</groupId>
 		    <artifactId>mule4-webcrawler-connector</artifactId>
-		    <version>0.3.27-SNAPSHOT</version>
+		    <version>0.3.28-SNAPSHOT</version>
 			<classifier>mule-plugin</classifier>
 		</dependency>
 		<dependency>

--- a/demo/mule-webcrawler-connector-operations-demo/src/main/mule/mule-webcrawler-connector-operations-demo.xml
+++ b/demo/mule-webcrawler-connector-operations-demo/src/main/mule/mule-webcrawler-connector-operations-demo.xml
@@ -194,8 +194,9 @@ output application/json
 				</ms-webcrawler:get-sitemap>
 			</when>
 			<otherwise >
-				<ms-webcrawler:get-sitemap doc:id="8968bf17-5c26-4f6a-a066-da5c0f17f6d2" doc:name="[HTTP] [Crawl] Get links as sitemap" maxDepth="#[attributes.queryParams.depth]" url="#[attributes.queryParams.url]" config-ref="HTTP_Configuration" restrictToPath="true">
+				<ms-webcrawler:get-sitemap doc:id="8968bf17-5c26-4f6a-a066-da5c0f17f6d2" doc:name="[HTTP] [Crawl] Get links as sitemap" maxDepth="#[attributes.queryParams.depth]" url="#[attributes.queryParams.url]" config-ref="HTTP_Configuration" restrictToPath="true" regexUrlsFilterLogic="INCLUDE">
 			<ms-webcrawler:regex-urls >
+						<ms-webcrawler:regex-url value="^https://docs\.nvidia\.com/cuda(?!.*\.(png|jpg|svg)$).*" />
 					</ms-webcrawler:regex-urls>
 		</ms-webcrawler:get-sitemap>
 			</otherwise>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.mulesoft.connectors</groupId>
     <artifactId>mule4-webcrawler-connector</artifactId>
-    <version>0.3.27-SNAPSHOT</version>
+    <version>0.3.28-SNAPSHOT</version>
     <packaging>mule-extension</packaging>
     <name>MuleSoft WebCrawler Connector - Mule 4</name>
 	<description>The MuleSoft WebCrawler Connector enables a Mule application to crawl websites and retrieve content, potentially for creating vector embeddings for structured knowledge extraction.</description>

--- a/src/main/java/org/mule/extension/webcrawler/internal/connection/WebCrawlerConnection.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/connection/WebCrawlerConnection.java
@@ -10,6 +10,9 @@ public interface WebCrawlerConnection {
   String getUserAgent();
   String getReferrer();
 
+  CompletableFuture<Integer> getUrlStatusCode(String url, String currentReferrer);
+  CompletableFuture<Integer> getUrlStatusCode(String url);
+
   CompletableFuture<InputStream> getPageSource(String url, String currentReferrer, PageLoadOptions pageLoadOptions);
   CompletableFuture<InputStream> getPageSource(String url, PageLoadOptions pageLoadOptions);
 }

--- a/src/main/java/org/mule/extension/webcrawler/internal/crawler/Crawler.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/crawler/Crawler.java
@@ -229,6 +229,8 @@ public abstract class Crawler {
     private String referrer;
     private String filename;
     private List<SiteNode> children;
+    @JsonIgnore
+    private SiteNode parent;
 
     public SiteNode(String url, int currentDepth, String referrer) {
 
@@ -236,6 +238,15 @@ public abstract class Crawler {
       this.currentDepth = currentDepth;
       this.referrer = referrer;
       this.children = new ArrayList<>();
+    }
+
+    public SiteNode(String url, int currentDepth, String referrer, SiteNode parent) {
+
+      this.url = url;
+      this.currentDepth = currentDepth;
+      this.referrer = referrer;
+      this.children = new ArrayList<>();
+      this.parent = parent;
     }
 
     public SiteNode(String url, int currentDepth, String referrer, String filename) {
@@ -273,6 +284,10 @@ public abstract class Crawler {
 
     public void addChild(SiteNode child) {
       this.children.add(child);
+    }
+
+    public SiteNode getParent() {
+      return parent;
     }
   }
 

--- a/src/main/java/org/mule/extension/webcrawler/internal/helper/page/PageHelper.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/helper/page/PageHelper.java
@@ -82,6 +82,26 @@ public class PageHelper {
     }
   }
 
+  public static boolean isURLValid(WebCrawlerConfiguration webCrawlerConfiguration,
+                                   WebCrawlerConnection connection,
+                                   String url,
+                                   String referrer){
+
+    LOGGER.debug(String.format("Retrieving status code for url %s and referer %s", url, referrer));
+    try {
+
+      Integer urlStatusCode = connection.getUrlStatusCode(url, referrer).get();
+      if(urlStatusCode != 200) {
+        LOGGER.debug(String.format("URL %s is not valid. Status code: %d", url, urlStatusCode));
+      }
+      return urlStatusCode == 200;
+
+    } catch (InterruptedException | ExecutionException e) {
+      LOGGER.error(String.format("Error while checking statur for url %s", url), e);
+      return false;
+    }
+  }
+
   public static JSONArray getPageMetaTags(Document document) {
     // Create a JSONArray to hold the structured meta tags
     JSONArray metaTagArray = new JSONArray();

--- a/src/main/java/org/mule/extension/webcrawler/internal/operation/CrawlOperations.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/operation/CrawlOperations.java
@@ -216,7 +216,7 @@ public class CrawlOperations {
           .build();
 
       Crawler.SiteNode root = crawler.map();
-      String sitemapXmlString = Crawler.SitemapGenerator.generateSitemapXml(root);
+      String sitemapXmlString = root != null ? Crawler.SitemapGenerator.generateSitemapXml(root) : "";
       int count = sitemapXmlString.split("<url>", -1).length - 1;
 
       return ResponseHelper.createSitemapResponse(


### PR DESCRIPTION
Verify URLs when building sitemap. #51

Today we have a discrepancy comparing sitemap and crawled nodes, this because we are not verifying if the leaf are valid urls. So when a leaf is invalid we get an error if we are crawling and we want content for that page. I want to check the leaf with a light method just to see if we get a 200 or 404.