### PR TITLE
Feature/html2markdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,18 +172,6 @@
 			<artifactId>commons-compress</artifactId>
 			<version>1.24.0</version>
 		</dependency>
-		<!-- Html 2 Markdown -->
-		<dependency>
-			<groupId>com.vladsch.flexmark</groupId>
-			<artifactId>flexmark-html2md-converter</artifactId>
-			<version>0.64.8</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.jsoup</groupId>
-					<artifactId>jsoup</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/ElementConverter.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/ElementConverter.java
@@ -1,0 +1,9 @@
+package org.mule.extension.webcrawler.internal.html2markdown;
+
+import org.jsoup.nodes.Element;
+
+import java.util.function.BiFunction;
+
+public interface ElementConverter {
+    String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth);
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/ElementConverterRegistry.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/ElementConverterRegistry.java
@@ -1,0 +1,45 @@
+package org.mule.extension.webcrawler.internal.html2markdown;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ElementConverterRegistry {
+
+    private final Map<String, ElementConverter> converters = new HashMap<>();
+    private final ElementConverter defaultConverter = new DefaultConverter();
+
+    public ElementConverterRegistry() {
+        registerConverter("h1", new HeadingConverter("# "));
+        registerConverter("h2", new HeadingConverter("## "));
+        registerConverter("h3", new HeadingConverter("### "));
+        registerConverter("h4", new HeadingConverter("#### "));
+        registerConverter("h5", new HeadingConverter("##### "));
+        registerConverter("h6", new HeadingConverter("###### "));
+        registerConverter("p", new ParagraphConverter());
+        registerConverter("strong", new BoldConverter());
+        registerConverter("b", new BoldConverter());
+        registerConverter("em", new EmphasisConverter());
+        registerConverter("i", new EmphasisConverter());
+        registerConverter("ul", new UnorderedListConverter());
+        registerConverter("ol", new OrderedListConverter());
+        registerConverter("li", new ListItemConverter());
+        registerConverter("br", new BreakConverter());
+        registerConverter("hr", new HorizontalRuleConverter());
+        registerConverter("table", new TableConverter());
+        registerConverter("blockquote", new BlockquoteConverter());
+        registerConverter("a", new LinkConverter());
+        registerConverter("img", new ImageConverter());
+        registerConverter("pre", new CodeBlockConverter());
+        registerConverter("span", new SpanConverter());
+        registerConverter("div", new DivConverter());
+        registerConverter("code", new CodeConverter()); // For inline <code>
+    }
+
+    public void registerConverter(String tagName, ElementConverter converter) {
+        converters.put(tagName, converter);
+    }
+
+    public ElementConverter getConverter(String tagName) {
+        return converters.getOrDefault(tagName, defaultConverter);
+    }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/HtmlToMarkdownConverter.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/HtmlToMarkdownConverter.java
@@ -1,0 +1,57 @@
+package org.mule.extension.webcrawler.internal.html2markdown;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+public class HtmlToMarkdownConverter {
+
+    private final ElementConverterRegistry converterRegistry;
+    private final int maxDepth;
+
+    public HtmlToMarkdownConverter(int maxDepth) {
+        this.converterRegistry = new ElementConverterRegistry();
+        this.maxDepth = maxDepth;
+    }
+
+    public String convert(String html) {
+        Document document = Jsoup.parse(html);
+        StringBuilder markdown = new StringBuilder();
+        for (Element element : document.body().children()) {
+            markdown.append(convertElement(element, 1));
+        }
+        return markdown.toString();
+    }
+
+    private String convertElement(Element element, int depth) {
+        if (depth > maxDepth) {
+            return ""; // Stop processing if depth exceeds the limit
+        }
+
+        ElementConverter converter = converterRegistry.getConverter(element.tagName());
+        StringBuilder markdown = new StringBuilder();
+
+        if (converter != null) {
+            markdown.append(converter.convert(element, this::convertElement, depth));
+        } else {
+            // Default behavior: process children and append text
+            for (Node node : element.childNodes()) {
+                if (node instanceof TextNode) {
+                    markdown.append(((TextNode) node).text());
+                } else if (node instanceof Element) {
+                    markdown.append(convertElement((Element) node, depth + 1));
+                }
+            }
+        }
+        return markdown.toString();
+    }
+
+    public static void main(String[] args) {
+        String html = "<div><h1>Hello</h1><p>This is a <strong><span>nested</span> paragraph</strong>.</p><ul><li>Item 1<ul><li>Sub-item</li></ul></li><li>Item 2</li></ul></div>";
+        HtmlToMarkdownConverter converter = new HtmlToMarkdownConverter(3); // Set max depth to 3
+        String markdown = converter.convert(html);
+        System.out.println(markdown);
+    }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/HtmlToMarkdownConverter.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/HtmlToMarkdownConverter.java
@@ -5,8 +5,12 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HtmlToMarkdownConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HtmlToMarkdownConverter.class);
 
     private final ElementConverterRegistry converterRegistry;
     private final int maxDepth;
@@ -27,6 +31,7 @@ public class HtmlToMarkdownConverter {
 
     private String convertElement(Element element, int depth) {
         if (depth > maxDepth) {
+            LOGGER.warn("Depth for URI {} is too large; review markdown output", element.baseUri());
             return ""; // Stop processing if depth exceeds the limit
         }
 
@@ -46,12 +51,5 @@ public class HtmlToMarkdownConverter {
             }
         }
         return markdown.toString();
-    }
-
-    public static void main(String[] args) {
-        String html = "<div><h1>Hello</h1><p>This is a <strong><span>nested</span> paragraph</strong>.</p><ul><li>Item 1<ul><li>Sub-item</li></ul></li><li>Item 2</li></ul></div>";
-        HtmlToMarkdownConverter converter = new HtmlToMarkdownConverter(3); // Set max depth to 3
-        String markdown = converter.convert(html);
-        System.out.println(markdown);
     }
 }

--- a/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/ListConverters.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/ListConverters.java
@@ -1,0 +1,63 @@
+package org.mule.extension.webcrawler.internal.html2markdown;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+import java.util.function.BiFunction;
+
+class UnorderedListConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder markdown = new StringBuilder();
+        for (Element li : element.select("> li")) { // Only direct children
+            markdown.append("* ");
+            for (Node node : li.childNodes()) {
+                if (node instanceof TextNode) {
+                    markdown.append(((TextNode) node).text());
+                } else if (node instanceof Element) {
+                    markdown.append(childConverter.apply((Element) node, depth + 1));
+                }
+            }
+            markdown.append("\n");
+        }
+        markdown.append("\n");
+        return markdown.toString();
+    }
+}
+
+class OrderedListConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder markdown = new StringBuilder();
+        int counter = 1;
+        for (Element li : element.select("> li")) { // Only direct children
+            markdown.append(counter++).append(". ");
+            for (Node node : li.childNodes()) {
+                if (node instanceof TextNode) {
+                    markdown.append(((TextNode) node).text());
+                } else if (node instanceof Element) {
+                    markdown.append(childConverter.apply((Element) node, depth + 1));
+                }
+            }
+            markdown.append("\n");
+        }
+        markdown.append("\n");
+        return markdown.toString();
+    }
+}
+
+class ListItemConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder content = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                content.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                content.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        return content.toString(); // List item content is handled by parent list
+    }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/MiscelleneousConverters.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/MiscelleneousConverters.java
@@ -1,0 +1,203 @@
+package org.mule.extension.webcrawler.internal.html2markdown;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.select.Elements;
+
+import java.util.function.BiFunction;
+
+class DefaultConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder markdown = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                markdown.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                markdown.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        return markdown.toString(); // Just process children by default
+    }
+}
+
+class TableConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        if (depth > 1) return element.text(); // Basic handling for nested tables
+
+        StringBuilder markdown = new StringBuilder();
+        Elements rows = element.select("tr");
+        if (rows.isEmpty()) {
+            return "";
+        }
+
+        // Header row
+        Elements headerCells = rows.first().select("th, td");
+        if (!headerCells.isEmpty()) {
+            for (int i = 0; i < headerCells.size(); i++) {
+                StringBuilder cellContent = new StringBuilder();
+                for (Node node : headerCells.get(i).childNodes()) {
+                    if (node instanceof TextNode) {
+                        cellContent.append(((TextNode) node).text());
+                    } else if (node instanceof Element) {
+                        cellContent.append(childConverter.apply((Element) node, depth + 1));
+                    }
+                }
+                markdown.append(cellContent.toString());
+                if (i < headerCells.size() - 1) {
+                    markdown.append(" | ");
+                }
+            }
+            markdown.append("\n");
+            for (int i = 0; i < headerCells.size(); i++) {
+                markdown.append("---");
+                if (i < headerCells.size() - 1) {
+                    markdown.append(" | ");
+                }
+            }
+            markdown.append("\n");
+        }
+
+        // Data rows
+        for (int i = (headerCells.isEmpty() ? 0 : 1); i < rows.size(); i++) {
+            Elements dataCells = rows.get(i).select("td");
+            for (int j = 0; j < dataCells.size(); j++) {
+                StringBuilder cellContent = new StringBuilder();
+                for (Node node : dataCells.get(j).childNodes()) {
+                    if (node instanceof TextNode) {
+                        cellContent.append(((TextNode) node).text());
+                    } else if (node instanceof Element) {
+                        cellContent.append(childConverter.apply((Element) node, depth + 1));
+                    }
+                }
+                markdown.append(cellContent.toString());
+                if (j < dataCells.size() - 1) {
+                    markdown.append(" | ");
+                }
+            }
+            markdown.append("\n");
+        }
+        markdown.append("\n");
+        return markdown.toString();
+    }
+}
+
+class BlockquoteConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder markdown = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                String[] lines = ((TextNode) node).text().split("\\n");
+                for (String line : lines) {
+                    markdown.append("> ").append(line.trim()).append("\n");
+                }
+            } else if (node instanceof Element) {
+                String childMarkdown = childConverter.apply((Element) node, depth + 1);
+                String[] lines = childMarkdown.split("\\n");
+                for (String line : lines) {
+                    markdown.append("> ").append(line).append("\n");
+                }
+            }
+        }
+        markdown.append("\n");
+        return markdown.toString();
+    }
+}
+
+class LinkConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        String href = element.attr("href");
+        StringBuilder text = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                text.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                text.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        if (href.isEmpty()) {
+            return text.toString();
+        }
+        return "[" + text.toString() + "](" + href + ")";
+    }
+}
+
+class ImageConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        String src = element.attr("src");
+        String alt = element.attr("alt");
+        if (src.isEmpty()) {
+            return "";
+        }
+        return "![" + alt + "](" + src + ")";
+    }
+}
+
+class CodeBlockConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        String language = "";
+        if (element.hasClass("language-") && element.className().contains("language-")) {
+            language = element.className().substring(element.className().indexOf("language-") + "language-".length()).split("\\s+")[0];
+        } else {
+            Element codeElement = element.selectFirst("code[data-language]");
+            if (codeElement != null) {
+                language = codeElement.attr("data-language");
+            }
+        }
+
+        StringBuilder content = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                content.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                // Do not process nested elements within code blocks as markdown
+                content.append(((Element) node).text());
+            }
+        }
+
+        return "```" + language + "\n" + content.toString() + "\n```\n\n";
+    }
+}
+
+class SpanConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder content = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                content.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                content.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        return content.toString(); // By default, just render the content inline
+    }
+}
+
+class DivConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder markdown = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                markdown.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                markdown.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        return markdown.toString() + "\n\n"; // Treat div as a block-level element with spacing
+    }
+}
+
+class CodeConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        return "`" + element.text() + "`"; // Inline code is wrapped in single backticks
+    }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/TextFormattingConverters.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/html2markdown/TextFormattingConverters.java
@@ -1,0 +1,87 @@
+package org.mule.extension.webcrawler.internal.html2markdown;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+import java.util.function.BiFunction;
+
+class HeadingConverter implements ElementConverter {
+    private final String prefix;
+
+    public HeadingConverter(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder content = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                content.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                content.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        return prefix + content.toString() + "\n\n";
+    }
+}
+
+class ParagraphConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder content = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                content.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                content.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        return content.toString() + "\n\n";
+    }
+}
+
+class BoldConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder content = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                content.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                content.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        return "**" + content.toString() + "**";
+    }
+}
+
+class EmphasisConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        StringBuilder content = new StringBuilder();
+        for (Node node : element.childNodes()) {
+            if (node instanceof TextNode) {
+                content.append(((TextNode) node).text());
+            } else if (node instanceof Element) {
+                content.append(childConverter.apply((Element) node, depth + 1));
+            }
+        }
+        return "*" + content.toString() + "*";
+    }
+}
+
+class BreakConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        return "\n";
+    }
+}
+
+class HorizontalRuleConverter implements ElementConverter {
+    @Override
+    public String convert(Element element, BiFunction<Element, Integer, String> childConverter, int depth) {
+        return "---\n";
+    }
+}

--- a/src/main/java/org/mule/extension/webcrawler/internal/util/Utils.java
+++ b/src/main/java/org/mule/extension/webcrawler/internal/util/Utils.java
@@ -1,12 +1,15 @@
 package org.mule.extension.webcrawler.internal.util;
 
-import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
+import org.mule.extension.webcrawler.internal.html2markdown.HtmlToMarkdownConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Utils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
+
+  // Should be thread-safe as no state is maintained in any of the converter classes
+  private static final HtmlToMarkdownConverter htmlToMarkdownConverter = new HtmlToMarkdownConverter(100);
 
   // Method to count words in a given text
   public static int countWords(String text) {
@@ -41,7 +44,6 @@ public class Utils {
   }
 
   public static String convertHtmlToMarkdown(String html) {
-
-    return FlexmarkHtmlConverter.builder().build().convert(html);
+    return htmlToMarkdownConverter.convert(html);
   }
 }


### PR DESCRIPTION
This PR consists of two commits:

- Implemented our own HTML to Markdown converter; removed the Flexmark dependency due to OOME issues.

- Simplified tag selector behavior for content extraction; the `isNestedInsideAnotherSelected` and `isDescendant` methods in `PageHelper` are producing unexpected results.  This change allows for a prioritized list of tags that are evaluated sequentially, and only the content of the first match is returned.  The full HTML is returned if no tags match.